### PR TITLE
Updated stagehand-downloads to point to the stagehand github release

### DIFF
--- a/stagehand/stagehand-downloads.html
+++ b/stagehand/stagehand-downloads.html
@@ -45,14 +45,20 @@
 </div>
 </div><!--header-->
 
-<h2>Version 0.77</h2>
+<h2>Latest Stagehand Release</h2>
 
+ 
+<p>
+<a href="https://github.com/dalihub/stagehand/releases/tag/version_0.77">Stagehand Release artifacts</a>
+</p>
+<br>
+ 
+ 
 <br>
 <h3> Windows </h3>
 
 <p>
-<a href="Stagehand_0.77.exe">Stagehand Windows Installer (32 & 64 bit)</a>
-</p>
+Run the executable installer</p>
 <br>
 
 
@@ -72,21 +78,10 @@ cd into the created directory, and run the installer as root:
 <p>$ sudo ./install.sh</p>
 </p>
 
-<p>
-<a href="stagehand-ubuntu-64bit-0.77.tar.gz">Stagehand 64bit Version 0.77</a>
-</p>
-
-<p>
-<a href="stagehand-ubuntu-32bit-0.77.tar.gz">Stagehand 32bit Version 0.77</a>
-</p>
-
-
 <br>
 <h3> OSX </h3>
 
-<p>
-<a href="stagehand.dmg"> Stagehand for OSX </a>
-</p>
+<p>Download "stagehand.dmg" from the above link</p>
 <br>
 
 


### PR DESCRIPTION
A release has been created for the stagehand github repo.
The stagehand download link in dalihub.github.io now points to this, so large binary files are not committed locally.